### PR TITLE
Mod Handbook and SkyrimAE info 

### DIFF
--- a/content/dnddc/readme.md
+++ b/content/dnddc/readme.md
@@ -86,6 +86,12 @@ Also make sure you have deleted or disabled any and all Creation Club content th
 ### Launching Skyrim
 Launch Skyrim SE to create any INI or registry entries the game needs. Immediately exit after the launcher has successfully selected a graphics preset for your hardware. The INIs will be overwritten by the ones included in the Wabbajack installer.
 
+{{< tip "warning" >}}
+**WARNING!**
+
+Currently, fresh installations of Skyrim Special Edition will be updated to an incompatable version for the lists to install. After you have a clean install of Skyrim Special Edition you will need to use the downgrade patcher featured **[HERE](https://www.nexusmods.com/skyrimspecialedition/mods/57618)** to ensure your Skyrim Special Edition install is the correct version before continuing with the steps in the Readme 
+{{< /tip >}}
+
 ### Wabbajack Preparations
 1. Download the latest version of Wabbajack. Do not run anything until instructed to do so. Make sure you are using the latest version of Wabbajack or else Wabbajack will report a corrupted modlist.
 2. Create a new folder in the root of the drive where you want Wabbajack to be installed. (C:\ will be used as an example, but it can be placed in any drive.) Name this folder “Wabbajack”.

--- a/content/livingskyrim/readme.md
+++ b/content/livingskyrim/readme.md
@@ -97,6 +97,12 @@ Once the above steps are completed, launch Skyrim SE through Steam to create any
 
 Last, but certainly not least, make sure you have deleted or disabled any and all Creation Club content that may have downloaded with the game.
 
+{{< tip "warning" >}}
+**WARNING!**
+
+Currently, fresh installations of Skyrim Special Edition will be updated to an incompatable version for the lists to install. After you have a clean install of Skyrim Special Edition you will need to use the downgrade patcher featured **[HERE](https://www.nexusmods.com/skyrimspecialedition/mods/57618)** to ensure your Skyrim Special Edition install is the correct version before continuing with the steps in the Readme 
+{{< /tip >}}
+
 ### Wabbajack Preparations
 We’ll now setup the folders needed for the installation to proceed smoothly.
 

--- a/content/modhandbook.md
+++ b/content/modhandbook.md
@@ -47,7 +47,7 @@ To ban someone, use this bot command, replacing things in brackets as appropriat
 
 To exile someone to Hotel Rule 11, use this bot command, replacing things in brackets as appropriate. Do not include the brackets.
 
-`!rolepersist [@Username] Rule 11 Breaker`
+`!rolepersist [@Username] Rule 11`
 
 ## User Notes
 
@@ -135,6 +135,16 @@ Here is a complete list of bot commands available to you:
 -   !hotelrule11 - Hotel Rule 11 meme
 
 -   !assign - Refers user to #role-assignment
+
+-   !dndkeymap - link to D&DDC keymap
+
+-   !dndbug - directs user to report D&DDC bug on github
+
+-   !scaling - information on adjusting windows display scaling for the modlists
+
+-   !skyrimae - information on Skyrim Anniversary Edition including a link to the downgrade patcher on nexus
+
+-   !maintenance - information on what the 'under maintenance' message means in Wabbajack
 
 If you want to recommend a command to be added to the list, just let me know and I'll get it done.
 

--- a/content/potd/readme.md
+++ b/content/potd/readme.md
@@ -69,11 +69,18 @@ Next, you’ll need a clean copy of Skyrim Special Edition. To get your copy to 
 2. If there are any files leftover in the Skyrim Special Edition game folder (Right-click > Manage > Browse Local Files), delete them.
 3. Install Skyrim: Special Edition.
 
+{{< tip "warning" >}}
+**WARNING!**
+
+Currently, fresh installations of Skyrim Special Edition will be updated to an incompatable version for the lists to install. After you have a clean install of Skyrim Special Edition you will need to use the downgrade patcher featured **[HERE](https://www.nexusmods.com/skyrimspecialedition/mods/57618)** to ensure your Skyrim Special Edition install is the correct version before continuing with the steps in the Readme 
+{{< /tip >}}
+
 {{< tip >}}
 **Protip:** 
 
 If you want to be absolutely certain you have uninstalled Skyrim completely, download and use Skyrim Shredder.
 {{< /tip >}}
+
 
 Afterwards, you need to disable automatic updates for Skyrim to avoid a game update breaking your copy of the game and therefore the modlist.
 
@@ -262,6 +269,14 @@ Don't forget to check back on your report periodically just in case we request m
 First, you can also try enabling the Network Workaround option in the settings for Wabbajack to see if it will download the file after enabling that setting.
 
 Otherwise, wait for an update to the list. The long answer is you can try to install the missing mods manually if the files are still available on the Nexus, but again, do not ask for anyone to share old files. I work a full-time job in addition to several other personal projects, of which Path of the Dovahkiin is just one. If installs are failing, I will try to update as quickly as possible but sometimes it may be a couple of days before I can get to it.
+
+#### "MEGA hosted files are failing to download."
+
+If MEGA downloads are either not downloading correctly or are frozen on the completed download page download the manually from the following links and place them in your POTD download folder:
+
+- [Smooth Random Blocking Animation](https://mega.nz/file/4LxGTALK#7I8XPLnIW0PxR_r_nXMP-9ZUnZ16MlFVMdFdgGy-gF0)
+- [Smooth Random Magic Idle Animation](https://mega.nz/file/IS4EjJhC#inP4yfb3i-UO_sx790OpoFDk81x-WIRf9WcBeKxnmYo)
+- [xLODGEN.84](https://mega.nz/file/dEwQnJRS#E-qpq29rVCBw3FxT3gTOjF_Z2zYkzR2CcWhQ5OAZcwg)
 
 #### “Wabbajack says I’m out of requests.”
 

--- a/content/potd/readme.md
+++ b/content/potd/readme.md
@@ -69,13 +69,7 @@ Next, you’ll need a clean copy of Skyrim Special Edition. To get your copy to 
 2. If there are any files leftover in the Skyrim Special Edition game folder (Right-click > Manage > Browse Local Files), delete them.
 3. Install Skyrim: Special Edition.
 
-{{< tip "warning" >}}
-**WARNING!**
 
-Currently, fresh installations of Skyrim Special Edition will be updated to an incompatable version for the lists to install. After you have a clean install of Skyrim Special Edition you will need to use the downgrade patcher featured **[HERE](https://www.nexusmods.com/skyrimspecialedition/mods/57618)** to ensure your Skyrim Special Edition install is the correct version before continuing with the steps in the Readme 
-{{< /tip >}}
-
-{{< tip >}}
 **Protip:** 
 
 If you want to be absolutely certain you have uninstalled Skyrim completely, download and use Skyrim Shredder.
@@ -90,6 +84,12 @@ Afterwards, you need to disable automatic updates for Skyrim to avoid a game upd
 Once the above steps are completed, launch Skyrim SE through Steam to create any INI or registry entries the game needs. Immediately exit the launcher once it has successfully selected a graphics preset for your hardware. The INIs it just created will be overwritten by the ones included in the modlist, but this is a necessary step for Wabbajack to recognize that you have the game installed.
 
 Last, but certainly not least, make sure you have deleted or disabled any and all Creation Club content that may have downloaded with the game.
+
+{{< tip "warning" >}}
+**WARNING!**
+
+Currently, fresh installations of Skyrim Special Edition will be updated to an incompatable version for the lists to install. After you have a clean install of Skyrim Special Edition you will need to use the downgrade patcher featured **[HERE](https://www.nexusmods.com/skyrimspecialedition/mods/57618)** to ensure your Skyrim Special Edition install is the correct version before continuing with the steps in the Readme 
+{{< /tip >}}
 
 ### Wabbajack Preparations
 We’ll now setup the folders needed for the installation to proceed smoothly.


### PR DESCRIPTION
Adds a few missing commands to the mod handbook

Adds warning blocks to each modlist's readme page under initial setup to include instructions to use the downgrade patcher to get the correct version of Skyrim SE

(NOTE: please check these warning blocks are formatted correctly, first time I've used them but they seemed appropriate for this instance)